### PR TITLE
u-boot-ingenic: add sdstart command and feature

### DIFF
--- a/arch/mips/lib/board.c
+++ b/arch/mips/lib/board.c
@@ -382,10 +382,6 @@ extern void board_usb_init(void);
 	printf("Autoupdate... \n");
 	run_command("sdupdate",0);
 #endif
-#ifdef CONFIG_CMD_SDSTART
-	printf("Loading external kernel image from MMC... \n");
-	run_command("sdstart",0);
-#endif
 
 	/* main_loop() can return to retry autoboot, if so just run it again. */
 	for (;;)

--- a/arch/mips/lib/board.c
+++ b/arch/mips/lib/board.c
@@ -382,10 +382,6 @@ extern void board_usb_init(void);
 	printf("Autoupdate... \n");
 	run_command("sdupdate",0);
 #endif
-#ifdef CONFIG_AUTO_UPDATE
-	printf("Autoupdate... \n");
-	run_command("sdupdate",0);
-#endif
 #ifdef CONFIG_CMD_SDSTART
 	printf("Loading external kernel image from MMC... \n");
 	run_command("sdstart",0);

--- a/arch/mips/lib/board.c
+++ b/arch/mips/lib/board.c
@@ -382,6 +382,14 @@ extern void board_usb_init(void);
 	printf("Autoupdate... \n");
 	run_command("sdupdate",0);
 #endif
+#ifdef CONFIG_AUTO_UPDATE
+	printf("Autoupdate... \n");
+	run_command("sdupdate",0);
+#endif
+#ifdef CONFIG_CMD_SDSTART
+	printf("Loading external kernel image from MMC... \n");
+	run_command("sdstart",0);
+#endif
 
 	/* main_loop() can return to retry autoboot, if so just run it again. */
 	for (;;)

--- a/arch/mips/lib/board.c
+++ b/arch/mips/lib/board.c
@@ -383,7 +383,6 @@ extern void board_usb_init(void);
 	run_command("sdupdate",0);
 #endif
 #ifdef CONFIG_CMD_SDSTART
-	printf("Loading external kernel image from MMC... \n");
 	run_command("sdstart",0);
 #endif
 

--- a/arch/mips/lib/board.c
+++ b/arch/mips/lib/board.c
@@ -382,6 +382,10 @@ extern void board_usb_init(void);
 	printf("Autoupdate... \n");
 	run_command("sdupdate",0);
 #endif
+#ifdef CONFIG_CMD_SDSTART
+	printf("Loading external kernel image from MMC... \n");
+	run_command("sdstart",0);
+#endif
 
 	/* main_loop() can return to retry autoboot, if so just run it again. */
 	for (;;)

--- a/common/Makefile
+++ b/common/Makefile
@@ -107,6 +107,7 @@ COBJS-$(CONFIG_SYS_HUSH_PARSER) += cmd_exit.o
 COBJS-$(CONFIG_CMD_EXT4) += cmd_ext4.o
 COBJS-$(CONFIG_CMD_EXT2) += cmd_ext2.o
 COBJS-$(CONFIG_CMD_FAT) += cmd_fat.o
+COBJS-$(CONFIG_CMD_SDSTART) += cmd_sdstart.o
 COBJS-$(CONFIG_CMD_SDUPDATE) += cmd_sdupdate.o
 COBJS-$(CONFIG_CMD_TFTPDOWNLOAD) += cmd_tftpdownload.o
 COBJS-$(CONFIG_CMD_WATCHDOG) += cmd_watchdog.o

--- a/common/cmd_sdstart.c
+++ b/common/cmd_sdstart.c
@@ -27,111 +27,122 @@
 #endif
 
 #define MAX_LOADSZ 0x500000
-#define DEFAULT_DELAY 1 // 1 second by default
+#define DEFAULT_DELAY 1 // Default delay is 1 second
 
 long sz = 0;
 char *aufiles = "factory_0P3N1PC_kernel";
 
+// This function prompts the user to press Ctrl-C to interrupt the kernel loading.
+// The prompt lasts for the specified delay (in seconds).
 static void prompt_and_wait_for_interrupt(int delay) {
-    printf("Press Ctrl-C to interrupt kernel loading within %d second(s)...\n", delay);
+    printf("You can interrupt kernel loading by pressing Ctrl-C within the next %d second(s)...\n", delay);
     int start = get_timer(0);
     while (get_timer(start) < (delay * 1000)) {
         if (ctrlc()) {
-            printf("Operation interrupted by user!\n");
+            printf("Kernel loading interrupted by user.\n");
             return;
         }
         udelay(10000); // Check every 10ms
     }
 }
 
+// This function checks if the checksum of the loaded kernel is valid.
 static int au_check_cksum_valid(long nbytes) {
     image_header_t *hdr;
     unsigned long checksum;
 
     hdr = (image_header_t *)LOAD_ADDR;
     if (nbytes != (sizeof(*hdr) + ntohl(hdr->ih_size))) {
-        printf("Image %s bad total SIZE\n", aufiles);
+        printf("Error: Invalid image size for %s.\n", aufiles);
         return -1;
     }
     checksum = ntohl(hdr->ih_dcrc);
     if (crc32(0, (unsigned char const *)(LOAD_ADDR + sizeof(*hdr)), ntohl(hdr->ih_size)) != checksum) {
-        printf("Image %s bad data checksum\n", aufiles);
+        printf("Error: Invalid data checksum for %s.\n", aufiles);
         return -1;
     }
     return 0;
 }
 
+// This function checks if the header of the loaded kernel is valid.
 static int au_check_header_valid(long nbytes) {
     image_header_t *hdr;
     unsigned long checksum;
     hdr = (image_header_t *)LOAD_ADDR;
 
     if (nbytes < sizeof(*hdr)) {
-        printf("Image %s bad header SIZE\n", aufiles);
+        printf("Error: Invalid header size for %s.\n", aufiles);
         return -1;
     }
     if (ntohl(hdr->ih_magic) != IH_MAGIC || hdr->ih_arch != IH_ARCH_MIPS) {
-        printf("Image %s bad MAGIC or ARCH\n", aufiles);
+        printf("Error: Invalid MAGIC or ARCH for %s.\n", aufiles);
         return -1;
     }
     checksum = ntohl(hdr->ih_hcrc);
     hdr->ih_hcrc = 0;
     if (crc32(0, (unsigned char const *)hdr, sizeof(*hdr)) != checksum) {
-        printf("Image %s bad header checksum\n", aufiles);
+        printf("Error: Invalid header checksum for %s.\n", aufiles);
         return -1;
     }
     if (hdr->ih_type != IH_TYPE_KERNEL) {
-        printf("Image %s wrong type\n", aufiles);
+        printf("Error: Invalid kernel type for %s.\n", aufiles);
         return -1;
     }
     return 0;
 }
 
+// This function loads the kernel from flash memory to RAM.
 static int update_to_flash(void) {
+    // Load the kernel header
     sz = file_fat_read(aufiles, LOAD_ADDR, sizeof(image_header_t));
     if (sz <= 0) {
-        printf("%s not found\n", aufiles);
+        printf("Error: File %s not found.\n", aufiles);
         return -1;
     }
+    // Validate the loaded kernel header
     if (au_check_header_valid(sz) < 0) {
-        printf("%s header not valid\n", aufiles);
+        printf("Error: Invalid header for %s.\n", aufiles);
         return -1;
     }
+    // Load the entire kernel
     sz = file_fat_read(aufiles, LOAD_ADDR, MAX_LOADSZ);
     if (sz <= 0) {
-        printf("%s not found\n", aufiles);
+        printf("Error: File %s not found.\n", aufiles);
         return -1;
     }
+    // Validate the loaded kernel checksum
     if (au_check_cksum_valid(sz) < 0) {
-        printf("%s checksum not valid\n", aufiles);
+        printf("Error: Invalid checksum for %s.\n", aufiles);
         return -1;
     }
     return 0;
 }
 
+// This function checks if the SD card is present and contains a valid FAT filesystem.
 static int do_check_sd(void) {
     int ret = 0;
     block_dev_desc_t *stor_dev;
 
     stor_dev = get_dev("mmc", 0);
     if(NULL == stor_dev) {
-        printf("MMC card is not present\n");
+        printf("Error: MMC card is not present.\n");
         return -1;
     }
     ret = fat_register_device(stor_dev, 1);
     if(ret != 0) {
-        printf("FAT device registration failed\n");
+        printf("Error: Failed to register FAT device.\n");
         return -1;
     }
     ret = file_fat_detectfs();
     if (ret != 0) {
-        printf("FAT filesystem detection failed\n");
+        printf("Error: Failed to detect FAT filesystem.\n");
         return -1;
     }
-    printf("FAT filesystem detected\n");
+    printf("FAT filesystem detected successfully.\n");
     return 0;
 }
 
+// This function sets the environment variables for booting the kernel.
 static void setenv_sd_start(void) {
     char bootargs[512];
     const char* osmem = getenv("osmem");
@@ -150,10 +161,12 @@ static void setenv_sd_start(void) {
     run_command("boot", 0);
 }
 
+// This is the main function that gets executed when the "sdstart" command is run in U-Boot.
 int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
     int old_ctrlc = 0;
     int delay = DEFAULT_DELAY;
 
+    // Check if the user has provided a custom delay value
     if (argc > 1) {
         delay = simple_strtol(argv[1], NULL, 10);
     }
@@ -162,9 +175,9 @@ int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
         printf("Operation was canceled during the prompt.\n");
         return 0;
     }
-    if (0 == do_check_sd()) {
+    if (do_check_sd() == 0) {
         old_ctrlc = disable_ctrlc(0);
-        if(0 == update_to_flash()) {
+        if(update_to_flash() == 0) {
             setenv_sd_start();
             return 0;
         }
@@ -175,6 +188,6 @@ int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
 
 U_BOOT_CMD(
     sdstart,    2,    0,    do_sd_start,
-    "load a kernel from the mmc card with an interruptible delay",
+    "Load a kernel from the MMC card with an interruptible delay.",
     "[delay_in_seconds]"
 );

--- a/common/cmd_sdstart.c
+++ b/common/cmd_sdstart.c
@@ -25,11 +25,12 @@
 #define CONFIG_BOOTCMD2 "bootm 0x83000000"
 #define LOAD_ADDR ((unsigned char *)0x83000000)
 #endif
+
 #define MAX_LOADSZ 0x500000
+#define DEFAULT_DELAY 1 // 1 second by default
 
 long sz = 0;
 char *aufiles = "factory_0P3N1PC_kernel";
-#define DEFAULT_DELAY 1 // 1 second by default
 
 static void prompt_and_wait_for_interrupt(int delay) {
     printf("Press Ctrl-C to interrupt kernel loading within %d second(s)...\n", delay);
@@ -43,172 +44,127 @@ static void prompt_and_wait_for_interrupt(int delay) {
     }
 }
 
-static int au_check_cksum_valid(long nbytes)
-{
+static int au_check_cksum_valid(long nbytes) {
     image_header_t *hdr;
     unsigned long checksum;
 
     hdr = (image_header_t *)LOAD_ADDR;
-
-    if (nbytes != (sizeof(*hdr) + ntohl(hdr->ih_size))) 
-    {
-        printf("sizeof(*hdr) + ntohl(hdr->ih_size):%d\n",(sizeof(*hdr) + ntohl(hdr->ih_size)));
-        printf("nbytes:%ld\n",nbytes);
+    if (nbytes != (sizeof(*hdr) + ntohl(hdr->ih_size))) {
         printf("Image %s bad total SIZE\n", aufiles);
         return -1;
     }
-
     checksum = ntohl(hdr->ih_dcrc);
-    if (crc32(0, (unsigned char const *)(LOAD_ADDR + sizeof(*hdr)), ntohl(hdr->ih_size)) != checksum) 
-    {
+    if (crc32(0, (unsigned char const *)(LOAD_ADDR + sizeof(*hdr)), ntohl(hdr->ih_size)) != checksum) {
         printf("Image %s bad data checksum\n", aufiles);
         return -1;
     }
-
     return 0;
 }
 
-static int au_check_header_valid(long nbytes)
-{
+static int au_check_header_valid(long nbytes) {
     image_header_t *hdr;
     unsigned long checksum;
-    char env[20];
     hdr = (image_header_t *)LOAD_ADDR;
 
-#undef CHECK_VALID_DEBUG
-#ifdef CHECK_VALID_DEBUG
-       printf("\nmagic %#x %#x\n", ntohl(hdr->ih_magic), IH_MAGIC);
-       printf("arch %#x %#x\n", hdr->ih_arch, IH_ARCH_MIPS);
-       printf("size %#x %#lx\n", ntohl(hdr->ih_size), nbytes);
-       printf("type %#x %#x\n", hdr->ih_type, IH_TYPE_FIRMWARE);
-#endif
-
-    if (nbytes < sizeof(*hdr)) 
-    {
+    if (nbytes < sizeof(*hdr)) {
         printf("Image %s bad header SIZE\n", aufiles);
         return -1;
     }
-    if (ntohl(hdr->ih_magic) != IH_MAGIC || hdr->ih_arch != IH_ARCH_MIPS) 
-    {
+    if (ntohl(hdr->ih_magic) != IH_MAGIC || hdr->ih_arch != IH_ARCH_MIPS) {
         printf("Image %s bad MAGIC or ARCH\n", aufiles);
         return -1;
     }
-
     checksum = ntohl(hdr->ih_hcrc);
     hdr->ih_hcrc = 0;
-
-    if (crc32(0, (unsigned char const *)hdr, sizeof(*hdr)) != checksum) 
-    {
+    if (crc32(0, (unsigned char const *)hdr, sizeof(*hdr)) != checksum) {
         printf("Image %s bad header checksum\n", aufiles);
         return -1;
     }
-    hdr->ih_hcrc = htonl(checksum);
-
-    if (hdr->ih_type != IH_TYPE_KERNEL)
-    {
+    if (hdr->ih_type != IH_TYPE_KERNEL) {
         printf("Image %s wrong type\n", aufiles);
         return -1;
     }
-
-    checksum = ntohl(hdr->ih_size);
-
-    if ((sz != 0) && (sz > checksum)) 
-    {
-        printf("Image %s is bigger than FLASH\n", aufiles);
-        return -1;
-    }
-    sprintf(env, "%lx", (unsigned long)ntohl(hdr->ih_time));
-
     return 0;
 }
 
-static int update_to_flash(void)
-{
+static int update_to_flash(void) {
     sz = file_fat_read(aufiles, LOAD_ADDR, sizeof(image_header_t));
-    if (sz <= 0 || sz < sizeof(image_header_t)) 
-    {
+    if (sz <= 0) {
         printf("%s not found\n", aufiles);
         return -1;
     }
-    if (au_check_header_valid(sz) < 0) 
-    {
+    if (au_check_header_valid(sz) < 0) {
         printf("%s header not valid\n", aufiles);
         return -1;
     }
     sz = file_fat_read(aufiles, LOAD_ADDR, MAX_LOADSZ);
-    if (sz <= 0 || sz <= sizeof(image_header_t)) 
-    {
+    if (sz <= 0) {
         printf("%s not found\n", aufiles);
         return -1;
     }
-    if (au_check_cksum_valid(sz) < 0)
-    {
+    if (au_check_cksum_valid(sz) < 0) {
         printf("%s checksum not valid\n", aufiles);
         return -1;
     }
-
     return 0;
 }
 
-static int do_check_sd(void)
-{
+static int do_check_sd(void) {
     int ret = 0;
     block_dev_desc_t *stor_dev;
 
     stor_dev = get_dev("mmc", 0);
-    if(NULL == stor_dev)
-    {
+    if(NULL == stor_dev) {
         printf("MMC card is not present\n");
         return -1;
     }
-
     ret = fat_register_device(stor_dev, 1);
-    if(0 != ret)
-    {
+    if(ret != 0) {
         printf("FAT device registration failed\n");
         return -1;
     }
-
     ret = file_fat_detectfs();
-    if (0 != ret)
-    {
+    if (ret != 0) {
         printf("FAT filesystem detection failed\n");
         return -1;
     }
     printf("FAT filesystem detected\n");
-
     return 0;
 }
 
-static void setenv_sd_start(void)
-{
-    setenv("bootargs",CONFIG_BOOTARGS2);
-    setenv("bootcmd",CONFIG_BOOTCMD2);
-    run_command("boot",0);
+static void setenv_sd_start(void) {
+    char bootargs[512];
+    const char* osmem = getenv("osmem");
+    const char* rmem = getenv("rmem");
+    const char* mtdparts = getenv("mtdparts");
+    const char* extras = getenv("extras");
+
+    snprintf(bootargs, sizeof(bootargs), "mem=%s rmem=%s console=ttyS1,115200n8 panic=20 root=/dev/mtdblock3 rootfstype=squashfs init=/init mtdparts=%s %s",
+             osmem ? osmem : "default_value",
+             rmem ? rmem : "default_value",
+             mtdparts ? mtdparts : "default_value",
+             extras ? extras : "");
+
+    setenv("bootargs", bootargs);
+    setenv("bootcmd", CONFIG_BOOTCMD2);
+    run_command("boot", 0);
 }
 
-int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[])
-{
+int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
     int old_ctrlc = 0;
     int delay = DEFAULT_DELAY;
 
-    // If user provides a different delay as an argument
     if (argc > 1) {
         delay = simple_strtol(argv[1], NULL, 10);
     }
-
     prompt_and_wait_for_interrupt(delay);
-
     if (ctrlc()) {
         printf("Operation was canceled during the prompt.\n");
         return 0;
     }
-
-    if (0 == do_check_sd())
-    {
+    if (0 == do_check_sd()) {
         old_ctrlc = disable_ctrlc(0);
-        if(0 == update_to_flash())
-        {
+        if(0 == update_to_flash()) {
             setenv_sd_start();
             return 0;
         }
@@ -219,6 +175,6 @@ int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[])
 
 U_BOOT_CMD(
     sdstart,    2,    0,    do_sd_start,
-    "auto sd start with interruptible delay",
-    "sdstart [delay_in_seconds]"
+    "load a kernel from the mmc card with an interruptible delay",
+    "[delay_in_seconds]"
 );

--- a/common/cmd_sdstart.c
+++ b/common/cmd_sdstart.c
@@ -186,13 +186,6 @@ static void configure_boot_environment(void) {
 
 // Main function when the "sdstart" command is run in U-Boot
 int sdstart(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
-	// Check if we are called from the autoupdate function
-	bool skip_init = false;
-
-	if (argc > 2 && strcmp(argv[2], "skip_init") == 0) {
-		skip_init = true;
-	}
-
 	// Fetch 'baseaddr' from the U-Boot environment
 	const char *baseaddr_str = getenv("baseaddr");
 	if (!baseaddr_str) {
@@ -204,10 +197,8 @@ int sdstart(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
 	LOAD_ADDR = (unsigned char *)simple_strtoul(baseaddr_str, NULL, 16);
 
 	// Validate the SD card
-	if (!skip_init) {
-		if (validate_sd_card() != 0) {
-			return -1; // Return early if SD card is not valid
-		}
+	if (validate_sd_card() != 0) {
+		return -1; // Return early if SD card is not valid
 	}
 
 	// Detect the kernel's presence without fully loading it

--- a/common/cmd_sdstart.c
+++ b/common/cmd_sdstart.c
@@ -1,193 +1,220 @@
 #include <common.h>
 #include <command.h>
-#include <fdtdec.h>
-#include <malloc.h>
-#include <menu.h>
-#include <post.h>
-#include <version.h>
-#include <watchdog.h>
-#include <linux/ctype.h>
 #include <environment.h>
 #include <image.h>
 #include <asm/byteorder.h>
-#include <asm/io.h>
-#include <spi_flash.h>
-#include <linux/mtd/mtd.h>
 #include <fat.h>
 #include <mmc.h>
 
-#ifdef CONFIG_DDR2_128M
-#define CONFIG_BOOTARGS2 "console=ttyS1,115200n8 mem=64M@0x0 rmem=64M@0x4000000 root=/dev/ram0 rw rdinit=/linuxrc"
-#define CONFIG_BOOTCMD2 "bootm 0x84000000"
-#define LOAD_ADDR ((unsigned char *)0x84000000)
-#else
-#define CONFIG_BOOTARGS2 "console=ttyS1,115200n8 mem=48M@0x0 rmem=16M@0x3000000 root=/dev/ram0 rw rdinit=/linuxrc"
-#define CONFIG_BOOTCMD2 "bootm 0x83000000"
-#define LOAD_ADDR ((unsigned char *)0x83000000)
-#endif
+// Enumerated error codes for various error scenarios
+typedef enum {
+	ERR_NONE = 0,
+	ERR_INVALID_IMAGE_SIZE,
+	ERR_INVALID_DATA_CKSUM,
+	ERR_INVALID_HEADER_SIZE,
+	ERR_INVALID_LOAD_ADDR,
+	ERR_INVALID_MAGIC_ARCH,
+	ERR_INVALID_HEADER_CKSUM,
+	ERR_INVALID_KERNEL_TYPE,
+	ERR_FILE_NOT_FOUND,
+	ERR_MMC_NOT_PRESENT,
+	ERR_FAT_REGISTRATION_FAIL,
+	ERR_FAT_DETECT_FAIL
+} ErrorCode;
 
-#define MAX_LOADSZ 0x500000
-#define DEFAULT_DELAY 1 // Default delay is 1 second
+// Memory address definition
+static unsigned char *LOAD_ADDR = NULL;
 
-long sz = 0;
-char *aufiles = "factory_0P3N1PC_kernel";
+// Format strings for boot arguments and commands
+#define MAX_LOADSZ 0xA00000  // Maximum load size, 10MB
+#define DEFAULT_DELAY 1      // Default delay is set to 1 second, begins only if the kernel image has been found
 
-// This function prompts the user to press Ctrl-C to interrupt the kernel loading.
-// The prompt lasts for the specified delay (in seconds).
-static void prompt_and_wait_for_interrupt(int delay) {
-    printf("You can interrupt kernel loading by pressing Ctrl-C within the next %d second(s)...\n", delay);
-    int start = get_timer(0);
-    while (get_timer(start) < (delay * 1000)) {
-        if (ctrlc()) {
-            printf("Kernel loading interrupted by user.\n");
-            return;
-        }
-        udelay(10000); // Check every 10ms
-    }
+// Name of the kernel file to load
+static const char * const kernel_filename = "factory_0P3N1PC_kernel";
+
+// This function prompts the user to press Ctrl-C to interrupt the kernel loading, lasting for the specified delay (in seconds).
+static bool prompt_and_wait_for_interrupt(int delay) {
+	printf("You can interrupt kernel loading by pressing Ctrl-C within the next %d second(s)...\n", delay);
+	unsigned long start = get_timer(0);
+
+	while (get_timer(0) - start < delay * 1000) {
+		if (ctrlc()) {
+			printf("Kernel loading interrupted by user.\n");
+			return true;
+		}
+		udelay(10000);  // Check every 10ms
+	}
+	return false;
 }
 
-// This function checks if the checksum of the loaded kernel is valid.
-static int au_check_cksum_valid(long nbytes) {
-    image_header_t *hdr;
-    unsigned long checksum;
-
-    hdr = (image_header_t *)LOAD_ADDR;
-    if (nbytes != (sizeof(*hdr) + ntohl(hdr->ih_size))) {
-        printf("Error: Invalid image size for %s.\n", aufiles);
-        return -1;
-    }
-    checksum = ntohl(hdr->ih_dcrc);
-    if (crc32(0, (unsigned char const *)(LOAD_ADDR + sizeof(*hdr)), ntohl(hdr->ih_size)) != checksum) {
-        printf("Error: Invalid data checksum for %s.\n", aufiles);
-        return -1;
-    }
-    return 0;
+// Function to handle and display errors based on ErrorCode
+static int handle_error(ErrorCode err, const char* context) {
+	switch (err) {
+		case ERR_INVALID_IMAGE_SIZE:
+			printf("Error: Invalid image size for %s.\n", context);
+			break;
+		case ERR_INVALID_DATA_CKSUM:
+			printf("Error: Invalid data checksum for %s.\n", context);
+			break;
+		case ERR_INVALID_HEADER_SIZE:
+			printf("Error: Invalid header size for %s.\n", context);
+			break;
+		case ERR_INVALID_MAGIC_ARCH:
+			printf("Error: Invalid MAGIC or ARCH for %s.\n", context);
+			break;
+		case ERR_INVALID_HEADER_CKSUM:
+			printf("Error: Invalid header checksum for %s.\n", context);
+			break;
+		case ERR_INVALID_KERNEL_TYPE:
+			printf("Error: Invalid kernel type for %s.\n", context);
+			break;
+		case ERR_FILE_NOT_FOUND:
+			printf("Error: File %s not found.\n", context);
+			break;
+		case ERR_MMC_NOT_PRESENT:
+			printf("Error: MMC card is not present.\n");
+			break;
+		case ERR_FAT_REGISTRATION_FAIL:
+			printf("Error: Failed to register FAT device.\n");
+			break;
+		case ERR_FAT_DETECT_FAIL:
+			printf("Error: Failed to detect FAT filesystem.\n");
+			break;
+		case ERR_INVALID_LOAD_ADDR:
+			printf("Error: Load ADDR is not initialized.\n");
+			break;
+		default:
+			break;
+	}
+	return -1;
 }
 
-// This function checks if the header of the loaded kernel is valid.
-static int au_check_header_valid(long nbytes) {
-    image_header_t *hdr;
-    unsigned long checksum;
-    hdr = (image_header_t *)LOAD_ADDR;
+// Function to validate the header and checksum of the loaded image
+static ErrorCode check_header_and_checksum_validity(long nbytes) {
+	// Load address initialization
+	if (!LOAD_ADDR) {
+		return ERR_INVALID_LOAD_ADDR;
+	}
 
-    if (nbytes < sizeof(*hdr)) {
-        printf("Error: Invalid header size for %s.\n", aufiles);
-        return -1;
-    }
-    if (ntohl(hdr->ih_magic) != IH_MAGIC || hdr->ih_arch != IH_ARCH_MIPS) {
-        printf("Error: Invalid MAGIC or ARCH for %s.\n", aufiles);
-        return -1;
-    }
-    checksum = ntohl(hdr->ih_hcrc);
-    hdr->ih_hcrc = 0;
-    if (crc32(0, (unsigned char const *)hdr, sizeof(*hdr)) != checksum) {
-        printf("Error: Invalid header checksum for %s.\n", aufiles);
-        return -1;
-    }
-    if (hdr->ih_type != IH_TYPE_KERNEL) {
-        printf("Error: Invalid kernel type for %s.\n", aufiles);
-        return -1;
-    }
-    return 0;
+	image_header_t *hdr = (image_header_t *)LOAD_ADDR;
+	unsigned long checksum;
+
+	if (nbytes < sizeof(*hdr)) {
+		return ERR_INVALID_HEADER_SIZE;
+	}
+
+	image_header_t local_hdr = *hdr;  // Create a local copy of the header
+	if (ntohl(local_hdr.ih_magic) != IH_MAGIC || local_hdr.ih_arch != IH_ARCH_MIPS) {
+		return ERR_INVALID_MAGIC_ARCH;
+	}
+
+	checksum = ntohl(local_hdr.ih_hcrc);
+	local_hdr.ih_hcrc = 0;
+
+	if (crc32(0, (unsigned char const *)&local_hdr, sizeof(local_hdr)) != checksum) {
+		return ERR_INVALID_HEADER_CKSUM;
+	}
+
+	if (local_hdr.ih_type != IH_TYPE_KERNEL) {
+		return ERR_INVALID_KERNEL_TYPE;
+	}
+
+	if (nbytes != (sizeof(local_hdr) + ntohl(local_hdr.ih_size))) {
+		return ERR_INVALID_IMAGE_SIZE;
+	}
+
+	checksum = ntohl(local_hdr.ih_dcrc);
+	if (crc32(0, (unsigned char const *)(LOAD_ADDR + sizeof(local_hdr)), ntohl(local_hdr.ih_size)) != checksum) {
+		return ERR_INVALID_DATA_CKSUM;
+	}
+
+	return ERR_NONE;
 }
 
-// This function loads the kernel from flash memory to RAM.
-static int update_to_flash(void) {
-    // Load the kernel header
-    sz = file_fat_read(aufiles, LOAD_ADDR, sizeof(image_header_t));
-    if (sz <= 0) {
-        printf("Error: File %s not found.\n", aufiles);
-        return -1;
-    }
-    // Validate the loaded kernel header
-    if (au_check_header_valid(sz) < 0) {
-        printf("Error: Invalid header for %s.\n", aufiles);
-        return -1;
-    }
-    // Load the entire kernel
-    sz = file_fat_read(aufiles, LOAD_ADDR, MAX_LOADSZ);
-    if (sz <= 0) {
-        printf("Error: File %s not found.\n", aufiles);
-        return -1;
-    }
-    // Validate the loaded kernel checksum
-    if (au_check_cksum_valid(sz) < 0) {
-        printf("Error: Invalid checksum for %s.\n", aufiles);
-        return -1;
-    }
-    return 0;
+// Function to load the kernel from MMC into RAM and validate its contents
+static int load_kernel_and_validate(void) {
+	long file_size = file_fat_read(kernel_filename, LOAD_ADDR, MAX_LOADSZ);
+	if (file_size <= 0) {
+		return handle_error(ERR_FILE_NOT_FOUND, kernel_filename);
+	}
+	ErrorCode err = check_header_and_checksum_validity(file_size);
+	if (err != ERR_NONE) {
+		return handle_error(err, kernel_filename);
+	}
+	return 0;
 }
 
-// This function checks if the SD card is present and contains a valid FAT filesystem.
-static int do_check_sd(void) {
-    int ret = 0;
-    block_dev_desc_t *stor_dev;
-
-    stor_dev = get_dev("mmc", 0);
-    if(NULL == stor_dev) {
-        printf("Error: MMC card is not present.\n");
-        return -1;
-    }
-    ret = fat_register_device(stor_dev, 1);
-    if(ret != 0) {
-        printf("Error: Failed to register FAT device.\n");
-        return -1;
-    }
-    ret = file_fat_detectfs();
-    if (ret != 0) {
-        printf("Error: Failed to detect FAT filesystem.\n");
-        return -1;
-    }
-    printf("FAT filesystem detected successfully.\n");
-    return 0;
+// Function to check if the SD card is present and contains a valid FAT filesystem
+static int validate_sd_card(void) {
+	block_dev_desc_t *stor_dev = get_dev("mmc", 0);
+	if(NULL == stor_dev) {
+		return handle_error(ERR_MMC_NOT_PRESENT, "");
+	}
+	int ret = fat_register_device(stor_dev, 1);
+	if(ret != 0) {
+		return handle_error(ERR_FAT_REGISTRATION_FAIL, "");
+	}
+	ret = file_fat_detectfs();
+	if (ret != 0) {
+		return handle_error(ERR_FAT_DETECT_FAIL, "");
+	}
+	printf("FAT filesystem detected successfully.\n");
+	return 0;
 }
 
-// This function sets the environment variables for booting the kernel.
-static void setenv_sd_start(void) {
-    char bootargs[512];
-    const char* osmem = getenv("osmem");
-    const char* rmem = getenv("rmem");
-    const char* mtdparts = getenv("mtdparts");
-    const char* extras = getenv("extras");
+// Function to set the environment variables for booting the kernel
+static void configure_boot_environment(void) {
+	char bootargs[512];
+	const char* osmem = getenv("osmem");
+	const char* rmem = getenv("rmem");
+	const char* mtdparts = getenv("mtdparts");
+	const char* extras = getenv("extras");
 
-    snprintf(bootargs, sizeof(bootargs), "mem=%s rmem=%s console=ttyS1,115200n8 panic=20 root=/dev/mtdblock3 rootfstype=squashfs init=/init mtdparts=%s %s",
-             osmem ? osmem : "default_value",
-             rmem ? rmem : "default_value",
-             mtdparts ? mtdparts : "default_value",
-             extras ? extras : "");
+	snprintf(bootargs, sizeof(bootargs),
+			"mem=%s rmem=%s console=ttyS1,115200n8 panic=20 root=/dev/mtdblock3 rootfstype=squashfs init=/init mtdparts=%s %s",
+			osmem ? osmem : "default_value",
+			rmem ? rmem : "default_value",
+			mtdparts ? mtdparts : "default_value",
+			extras ? extras : "");
 
-    setenv("bootargs", bootargs);
-    setenv("bootcmd", CONFIG_BOOTCMD2);
-    run_command("boot", 0);
+	char bootcmd[512];
+	snprintf(bootcmd, sizeof(bootcmd), "bootm %p", LOAD_ADDR);
+	setenv("bootargs", bootargs);
+	setenv("bootcmd", bootcmd);
+	run_command("boot", 0);
 }
 
-// This is the main function that gets executed when the "sdstart" command is run in U-Boot.
-int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
-    int old_ctrlc = 0;
-    int delay = DEFAULT_DELAY;
+// Main function when the "sdstart" command is run in U-Boot
+int sdstart(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
+	// Fetch 'baseaddr' from the U-Boot environment
+	const char *baseaddr_str = getenv("baseaddr");
+	if (!baseaddr_str) {
+		printf("Error: 'baseaddr' not found in the environment.\n");
+		return -1;
+	}
 
-    // Check if the user has provided a custom delay value
-    if (argc > 1) {
-        delay = simple_strtol(argv[1], NULL, 10);
-    }
-    prompt_and_wait_for_interrupt(delay);
-    if (ctrlc()) {
-        printf("Operation was canceled during the prompt.\n");
-        return 0;
-    }
-    if (do_check_sd() == 0) {
-        old_ctrlc = disable_ctrlc(0);
-        if(update_to_flash() == 0) {
-            setenv_sd_start();
-            return 0;
-        }
-        disable_ctrlc(old_ctrlc);
-    }
-    return 0;
+	// Convert string to pointer (address)
+	LOAD_ADDR = (unsigned char *)simple_strtoul(baseaddr_str, NULL, 16);
+
+	int delay = (argc > 1) ? simple_strtol(argv[1], NULL, 10) : DEFAULT_DELAY;
+	if (prompt_and_wait_for_interrupt(delay)) {
+		printf("Operation was canceled during the prompt.\n");
+		return 0;
+	}
+	if (validate_sd_card() == 0) {
+		int old_ctrlc = disable_ctrlc(0);
+		if(load_kernel_and_validate() == 0) {
+			configure_boot_environment();
+			return 0;
+		}
+		disable_ctrlc(old_ctrlc);
+	}
+	return 0;
 }
 
 U_BOOT_CMD(
-    sdstart,    2,    0,    do_sd_start,
-    "Load a kernel from the MMC card with an interruptible delay.",
-    "[delay_in_seconds]"
+	sdstart,	2,	0,	sdstart,
+	"Load a kernel from the MMC card with an interruptible delay.",
+	"[delay_in_seconds]"
 );
+

--- a/common/cmd_sdstart.c
+++ b/common/cmd_sdstart.c
@@ -1,0 +1,224 @@
+#include <common.h>
+#include <command.h>
+#include <fdtdec.h>
+#include <malloc.h>
+#include <menu.h>
+#include <post.h>
+#include <version.h>
+#include <watchdog.h>
+#include <linux/ctype.h>
+#include <environment.h>
+#include <image.h>
+#include <asm/byteorder.h>
+#include <asm/io.h>
+#include <spi_flash.h>
+#include <linux/mtd/mtd.h>
+#include <fat.h>
+#include <mmc.h>
+
+#ifdef CONFIG_DDR2_128M
+#define CONFIG_BOOTARGS2 "console=ttyS1,115200n8 mem=64M@0x0 rmem=64M@0x4000000 root=/dev/ram0 rw rdinit=/linuxrc"
+#define CONFIG_BOOTCMD2 "bootm 0x84000000"
+#define LOAD_ADDR ((unsigned char *)0x84000000)
+#else
+#define CONFIG_BOOTARGS2 "console=ttyS1,115200n8 mem=48M@0x0 rmem=16M@0x3000000 root=/dev/ram0 rw rdinit=/linuxrc"
+#define CONFIG_BOOTCMD2 "bootm 0x83000000"
+#define LOAD_ADDR ((unsigned char *)0x83000000)
+#endif
+#define MAX_LOADSZ 0x500000
+
+long sz = 0;
+char *aufiles = "factory_0P3N1PC_kernel";
+#define DEFAULT_DELAY 1 // 1 second by default
+
+static void prompt_and_wait_for_interrupt(int delay) {
+    printf("Press Ctrl-C to interrupt kernel loading within %d second(s)...\n", delay);
+    int start = get_timer(0);
+    while (get_timer(start) < (delay * 1000)) {
+        if (ctrlc()) {
+            printf("Operation interrupted by user!\n");
+            return;
+        }
+        udelay(10000); // Check every 10ms
+    }
+}
+
+static int au_check_cksum_valid(long nbytes)
+{
+    image_header_t *hdr;
+    unsigned long checksum;
+
+    hdr = (image_header_t *)LOAD_ADDR;
+
+    if (nbytes != (sizeof(*hdr) + ntohl(hdr->ih_size))) 
+    {
+        printf("sizeof(*hdr) + ntohl(hdr->ih_size):%d\n",(sizeof(*hdr) + ntohl(hdr->ih_size)));
+        printf("nbytes:%ld\n",nbytes);
+        printf("Image %s bad total SIZE\n", aufiles);
+        return -1;
+    }
+
+    checksum = ntohl(hdr->ih_dcrc);
+    if (crc32(0, (unsigned char const *)(LOAD_ADDR + sizeof(*hdr)), ntohl(hdr->ih_size)) != checksum) 
+    {
+        printf("Image %s bad data checksum\n", aufiles);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int au_check_header_valid(long nbytes)
+{
+    image_header_t *hdr;
+    unsigned long checksum;
+    char env[20];
+    hdr = (image_header_t *)LOAD_ADDR;
+
+#undef CHECK_VALID_DEBUG
+#ifdef CHECK_VALID_DEBUG
+       printf("\nmagic %#x %#x\n", ntohl(hdr->ih_magic), IH_MAGIC);
+       printf("arch %#x %#x\n", hdr->ih_arch, IH_ARCH_MIPS);
+       printf("size %#x %#lx\n", ntohl(hdr->ih_size), nbytes);
+       printf("type %#x %#x\n", hdr->ih_type, IH_TYPE_FIRMWARE);
+#endif
+
+    if (nbytes < sizeof(*hdr)) 
+    {
+        printf("Image %s bad header SIZE\n", aufiles);
+        return -1;
+    }
+    if (ntohl(hdr->ih_magic) != IH_MAGIC || hdr->ih_arch != IH_ARCH_MIPS) 
+    {
+        printf("Image %s bad MAGIC or ARCH\n", aufiles);
+        return -1;
+    }
+
+    checksum = ntohl(hdr->ih_hcrc);
+    hdr->ih_hcrc = 0;
+
+    if (crc32(0, (unsigned char const *)hdr, sizeof(*hdr)) != checksum) 
+    {
+        printf("Image %s bad header checksum\n", aufiles);
+        return -1;
+    }
+    hdr->ih_hcrc = htonl(checksum);
+
+    if (hdr->ih_type != IH_TYPE_KERNEL)
+    {
+        printf("Image %s wrong type\n", aufiles);
+        return -1;
+    }
+
+    checksum = ntohl(hdr->ih_size);
+
+    if ((sz != 0) && (sz > checksum)) 
+    {
+        printf("Image %s is bigger than FLASH\n", aufiles);
+        return -1;
+    }
+    sprintf(env, "%lx", (unsigned long)ntohl(hdr->ih_time));
+
+    return 0;
+}
+
+static int update_to_flash(void)
+{
+    sz = file_fat_read(aufiles, LOAD_ADDR, sizeof(image_header_t));
+    if (sz <= 0 || sz < sizeof(image_header_t)) 
+    {
+        printf("%s not found\n", aufiles);
+        return -1;
+    }
+    if (au_check_header_valid(sz) < 0) 
+    {
+        printf("%s header not valid\n", aufiles);
+        return -1;
+    }
+    sz = file_fat_read(aufiles, LOAD_ADDR, MAX_LOADSZ);
+    if (sz <= 0 || sz <= sizeof(image_header_t)) 
+    {
+        printf("%s not found\n", aufiles);
+        return -1;
+    }
+    if (au_check_cksum_valid(sz) < 0)
+    {
+        printf("%s checksum not valid\n", aufiles);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int do_check_sd(void)
+{
+    int ret = 0;
+    block_dev_desc_t *stor_dev;
+
+    stor_dev = get_dev("mmc", 0);
+    if(NULL == stor_dev)
+    {
+        printf("MMC card is not present\n");
+        return -1;
+    }
+
+    ret = fat_register_device(stor_dev, 1);
+    if(0 != ret)
+    {
+        printf("FAT device registration failed\n");
+        return -1;
+    }
+
+    ret = file_fat_detectfs();
+    if (0 != ret)
+    {
+        printf("FAT filesystem detection failed\n");
+        return -1;
+    }
+    printf("FAT filesystem detected\n");
+
+    return 0;
+}
+
+static void setenv_sd_start(void)
+{
+    setenv("bootargs",CONFIG_BOOTARGS2);
+    setenv("bootcmd",CONFIG_BOOTCMD2);
+    run_command("boot",0);
+}
+
+int do_sd_start(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[])
+{
+    int old_ctrlc = 0;
+    int delay = DEFAULT_DELAY;
+
+    // If user provides a different delay as an argument
+    if (argc > 1) {
+        delay = simple_strtol(argv[1], NULL, 10);
+    }
+
+    prompt_and_wait_for_interrupt(delay);
+
+    if (ctrlc()) {
+        printf("Operation was canceled during the prompt.\n");
+        return 0;
+    }
+
+    if (0 == do_check_sd())
+    {
+        old_ctrlc = disable_ctrlc(0);
+        if(0 == update_to_flash())
+        {
+            setenv_sd_start();
+            return 0;
+        }
+        disable_ctrlc(old_ctrlc);
+    }
+    return 0;
+}
+
+U_BOOT_CMD(
+    sdstart,    2,    0,    do_sd_start,
+    "auto sd start with interruptible delay",
+    "sdstart [delay_in_seconds]"
+);

--- a/common/cmd_sdstart.c
+++ b/common/cmd_sdstart.c
@@ -96,7 +96,7 @@ static int handle_error(ErrorCode err, const char* context) {
 			printf("Error: Invalid kernel type for %s.\n", context);
 			break;
 		case ERR_FILE_NOT_FOUND:
-			printf("Error: File %s not found.\n", context);
+			printf("Error: Kernel file not found.\n", context);
 			break;
 		case ERR_MMC_NOT_PRESENT:
 			printf("Error: MMC card is not present.\n");
@@ -181,18 +181,21 @@ static int load_kernel_and_validate(void) {
 static int validate_sd_card(void) {
 	block_dev_desc_t *stor_dev = get_dev("mmc", 0);
 	if(NULL == stor_dev) {
-		return handle_error(ERR_MMC_NOT_PRESENT, "");
+		handle_error(ERR_MMC_NOT_PRESENT, "");
+		return false;
 	}
 	int ret = fat_register_device(stor_dev, 1);
 	if(ret != 0) {
-		return handle_error(ERR_FAT_REGISTRATION_FAIL, "");
+		handle_error(ERR_FAT_REGISTRATION_FAIL, "");
+		return false;
 	}
 	ret = file_fat_detectfs();
 	if (ret != 0) {
-		return handle_error(ERR_FAT_DETECT_FAIL, "");
+		handle_error(ERR_FAT_DETECT_FAIL, "");
+		return false;
 	}
 	printf("FAT filesystem detected successfully.\n");
-	return 0;
+	return true;
 }
 
 // Function to set the environment variables for booting the kernel
@@ -230,7 +233,7 @@ int sdstart(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]) {
 	LOAD_ADDR = (unsigned char *)simple_strtoul(baseaddr_str, NULL, 16);
 
 	// Validate the SD card
-	if (validate_sd_card() != 0) {
+	if (!validate_sd_card() != 0) {
 		return 0; // Return early if SD card is not valid, silently
 	}
 

--- a/common/cmd_sdupdate.c
+++ b/common/cmd_sdupdate.c
@@ -15,8 +15,6 @@
 
 #ifdef CONFIG_AUTO_UPDATE  /* cover the whole file */
 
-extern int sdstart(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]);
-
 #ifdef CONFIG_AUTO_SD_UPDATE
 #ifndef CONFIG_MMC
 #error "should have defined CONFIG_MMC"
@@ -429,13 +427,6 @@ int do_auto_update(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 
 	state = update_to_flash();
 
-
-	// If no update files are found, call sdstart to check for kernel
-	if (state == -1) {
-		printf("No auto-update files found. Checking for kernel to start from MMC...\n");
-		char *args[] = {"sdstart", "1", "skip_init"};
-		return sdstart(cmdtp, flag, 3, args);
-	}
 
 	/* restore the old state */
 	disable_ctrlc(old_ctrlc);

--- a/common/cmd_sdupdate.c
+++ b/common/cmd_sdupdate.c
@@ -15,6 +15,8 @@
 
 #ifdef CONFIG_AUTO_UPDATE  /* cover the whole file */
 
+extern int sdstart(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[]);
+
 #ifdef CONFIG_AUTO_SD_UPDATE
 #ifndef CONFIG_MMC
 #error "should have defined CONFIG_MMC"
@@ -427,6 +429,13 @@ int do_auto_update(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 
 	state = update_to_flash();
 
+
+	// If no update files are found, call sdstart to check for kernel
+	if (state == -1) {
+		printf("No auto-update files found. Checking for kernel to start from MMC...\n");
+		char *args[] = {"sdstart", "1", "skip_init"};
+		return sdstart(cmdtp, flag, 3, args);
+	}
 
 	/* restore the old state */
 	disable_ctrlc(old_ctrlc);

--- a/include/configs/isvp_common.h
+++ b/include/configs/isvp_common.h
@@ -116,3 +116,4 @@
 #ifdef CONFIG_AUTO_UPDATE
     #define CONFIG_CMD_SDUPDATE	1
 #endif
+#define CONFIG_CMD_SDSTART	1


### PR DESCRIPTION
**New Functionality Added to u-boot-ingenic: `sdstart` Command**

**Description:** 
The `sdstart` command is introduced to allow users to load a kernel from the MMC card with an option to interrupt the loading process after a specified delay.

**Usage:**
The `sdstart` command can be invoked directly from the u-boot command line. Alternatively, if the file named `factory_0P3N1PC_kernel` is located at the root of the MMC card, the command will execute automatically.

**Operation Flow:**

Upon execution, the following sequence is observed:

1. The system initializes and identifies the MMC interface and its specifications:

   ```
   Autoupdate... 
   Interface:  MMC
     Device 0: Vendor: Man 000074 Snr 000e5a01 Rev: 0.0 Prod: SD16G 
               Type: Removable Hard Disk
               Capacity: 7619.0 MB = 7.4 GB (15603712 x 512)
   Filesystem: FAT32 "test       "
   the manufacturer 1c
   SF: Detected EN25QH128A
   ```

2. The system searches for autoupdate files:

   ```
   reading autoupdate-uboot.img
   reading autoupdate-kernel.img
   reading autoupdate-rootfs.img
   reading autoupdate-full.img
   ```

3. If no autoupdate files are detected, the system checks for the `factory_0P3N1PC_kernel` file to start the kernel from the MMC:

   ```
   No auto-update files found. Checking for kernel to start from MMC...
   ```

4. The user is given a prompt, allowing them to interrupt the kernel loading process:

   ```
   reading factory_0P3N1PC_kernel
   You can interrupt kernel loading by pressing Ctrl-C within the next 1 second(s)...
   ```

5. If not interrupted, the kernel loading process continues:

   ```
   reading factory_0P3N1PC_kernel
   ## Booting kernel from Legacy Image at 80600000 ...
      Image Name:   Linux-3.10.14__isvp_swan_1.0__-t
      Image Type:   MIPS Linux Kernel Image (lzma compressed)
      Data Size:    1868132 Bytes = 1.8 MiB
      Load Address: 80010000
      Entry Point:  803f7770
      Verifying Checksum ... OK
      Uncompressing Kernel Image ... OK

   Starting kernel ...
   ...
   ```
   
6. If no kernel is found, the system boots from the flash storage as normal.  

I hope this provides a clear understanding of the `sdstart` functionality and its operation flow.


---


Tested on: 

T20:
WyzeCam v2
WyzeCam v2 black

T31:
Wyze Pan  V2
Wyze V3
Wyze Doorbell3
AtomCam 2